### PR TITLE
feat: use default user login shell for exec

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -13,11 +13,11 @@ func execCommand(c *cli.Context) error {
 		return fmt.Errorf("Missing environment name")
 	}
 
-	_, id, err := containerenv.GetConfig(envName)
+	conf, id, err := containerenv.GetConfig(envName)
 	if err != nil {
 		return err
 	}
 
-	err = containerenv.Exec(id)
+	err = containerenv.Exec(id, conf)
 	return err
 }


### PR DESCRIPTION
This will look at `/etc/passwd` to determine which shell is set for the user's login shell and use that. If the command or lookup fails, we fall back to `bash`